### PR TITLE
Add link to finding in the extended help text for a rule in SARIF output

### DIFF
--- a/sarif/json2sarif.py
+++ b/sarif/json2sarif.py
@@ -55,7 +55,7 @@ for finding in json:
         "id": rule_id,
         "name": finding['meta']['description'],
         "fullDescription": {
-            "text": finding['spec']['explanation']
+            "text": f"{finding['spec']['explanation']}\n\n[Finding {finding['uuid'][-7:]}](https://app.endorlabs.com/t/{finding['tenant_meta']['namespace']}/findings/{finding['uuid']})"
         },
         "help": {
             "text": finding['spec']['remediation']

--- a/sarif/json2sarif.py
+++ b/sarif/json2sarif.py
@@ -55,10 +55,10 @@ for finding in json:
         "id": rule_id,
         "name": finding['meta']['description'],
         "fullDescription": {
-            "text": f"{finding['spec']['explanation']}\n\n[Finding {finding['uuid'][-7:]}](https://app.endorlabs.com/t/{finding['tenant_meta']['namespace']}/findings/{finding['uuid']})"
+            "text": f"{finding['spec']['explanation']"
         },
         "help": {
-            "text": finding['spec']['remediation']
+            "text": f"{finding['spec']['remediation']}\n\n[see finding {finding['uuid'][-7:]}](https://app.endorlabs.com/t/{finding['tenant_meta']['namespace']}/findings/{finding['uuid']})"
         },
         "shortDescription": {
             "text": finding['spec']['summary']

--- a/sarif/json2sarif.py
+++ b/sarif/json2sarif.py
@@ -55,7 +55,7 @@ for finding in json:
         "id": rule_id,
         "name": finding['meta']['description'],
         "fullDescription": {
-            "text": f"{finding['spec']['explanation']"
+            "text": finding['spec']['explanation']
         },
         "help": {
             "text": f"{finding['spec']['remediation']}\n\n[see finding {finding['uuid'][-7:]}](https://app.endorlabs.com/t/{finding['tenant_meta']['namespace']}/findings/{finding['uuid']})"


### PR DESCRIPTION
When uploaded to GHAS, the help text -- visible when opening an issue from the Security Tab -- will contain a "see more"; when expanded, this will provide a link to the finding in Endor Labs' Web UI.